### PR TITLE
Weather Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,10 @@ ENV/
 env.bak/
 venv.bak/
 
+# Pipenv
+Pipfile
+Pipfile.lock
+
 # Spyder project settings
 .spyderproject
 .spyproject
@@ -152,6 +156,10 @@ flycheck_*.el
 
 # directory configuration
 .dir-locals.el
+
+# JetBrains
+.idea/
+*.iws
 
 # A2
 *config.json

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ flycheck_*.el
 
 # A2
 *config.json
+/A2/config/

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -62,13 +62,8 @@ class WeatherPlugin(Plugin):
             event.msg.reply(f'Could not find weather for `{location}`.')
             return
 
-        embed: MessageEmbed = MessageEmbed()
-        embed.set_author(
-            name='Yahoo! Weather',
-            url='https://www.yahoo.com/news/weather',
-            icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
+        embed: MessageEmbed = self.get_base_embed(result)
         embed.title = result.print_obj['item']['title']
-        embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
         embed.set_thumbnail(url=self.get_thumbnail(result.condition.code))
         embed.description = result.condition.text
         embed.add_field(
@@ -111,13 +106,8 @@ class WeatherPlugin(Plugin):
             event.msg.reply(f'Could not retrieve a forecast for `{location}`.')
             return
 
-        embed: MessageEmbed = MessageEmbed()
-        embed.set_author(
-            name='Yahoo! Weather',
-            url='https://www.yahoo.com/news/weather',
-            icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
+        embed: MessageEmbed = self.get_base_embed(result)
         embed.title = f'10-day Weather Forecast for {result.title[17:]}'
-        embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
 
         for forecast in result.forecast:
             emoji: str = WeatherPlugin.get_emoji(forecast.code)
@@ -130,6 +120,17 @@ class WeatherPlugin(Plugin):
                 inline=True)
 
         event.msg.reply(embed=embed)
+
+    @staticmethod
+    def get_base_embed(result: WeatherObject) -> MessageEmbed:
+        embed: MessageEmbed = MessageEmbed()
+        embed.set_author(
+            name='Yahoo! Weather',
+            url='https://www.yahoo.com/news/weather',
+            icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
+        embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
+
+        return embed
 
     @staticmethod
     def format_temp(result: WeatherObject):

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -6,6 +6,7 @@ from disco.bot import Plugin
 from disco.bot.command import CommandEvent
 from disco.types.message import MessageEmbed
 from weather.weather import Weather, WeatherObject
+from weather.objects.forecast_obj import Forecast
 from weather.objects.unit_obj import Unit
 from weather.objects.wind_obj import Wind
 
@@ -60,7 +61,7 @@ class WeatherPlugin(Plugin):
         embed.description = result.condition.text
         embed.add_field(
             name='Temperature',
-            value=f'{result.condition.temp}° {result.units.temperature}',
+            value=self.format_temp(result),
             inline=True)
         embed.add_field(
             name='Atmosphere',
@@ -83,6 +84,14 @@ class WeatherPlugin(Plugin):
                 url=f'http://openweathermap.org/img/w/{self.ICONS[code]}.png')
 
         event.msg.reply(embed=embed)
+
+    @staticmethod
+    def format_temp(result: WeatherObject):
+        forecast: Forecast = result.forecast[0]
+
+        return f'{result.condition.temp}° {result.units.temperature}\n' \
+               f'High: {forecast.high}° {result.units.temperature}\n' \
+               f'Low: {forecast.low}° {result.units.temperature}'
 
     @staticmethod
     def format_atmosphere(atm: dict, units: Unit) -> str:

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -118,6 +118,7 @@ class WeatherPlugin(Plugin):
             url='https://www.yahoo.com/news/weather',
             icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
         embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
+        embed.color = 4194448 # Yahoo! logo's purple.
 
         return embed
 

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -1,0 +1,88 @@
+from disco.bot import Plugin
+from disco.types.message import MessageEmbed
+from weather.weather import Weather, WeatherObject
+from weather.objects.unit_obj import Unit
+from weather.objects.wind_obj import Wind
+
+
+class WeatherPlugin(Plugin):
+    CARDINAL_DIRS = (
+        'N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW',
+        'WSW', 'W', 'WNW', 'NW', 'NNW')
+    PRESSURE_STATES = ('steady', 'rising', 'falling')
+    ICONS = (
+        '50d', '11d', '50d', '11d', '11d', '13d', '13d', '13d', '09d', '09d',
+        '09d', '09d', '09d', '13d', '13d', '13d', '13d', '09d', '13d', '50d',
+        '50d', '50d', '50d', '50d', '50d', '13d', '03d', '02n', '02d', '02n',
+        '02d', '01n', '01d', '01n', '01d', '09d', '01d', '11d', '11d', '11d',
+        '09d', '13d', '13d', '13d', '04d', '11d', '13d', '11d')
+    ICON_BASE = 'http://openweathermap.org/img/w/'
+
+    def __init__(self, bot, config):
+        super().__init__(bot, config)
+
+        self.weather = Weather()
+
+    @Plugin.command('weather', '<location:str...>')
+    def weather_command(self, event, location):
+        result: WeatherObject = self.weather.lookup_by_location(location)
+
+        if not result:
+            event.msg.reply(f'Could not find weather for `{location}`.')
+            return
+
+        embed: MessageEmbed = MessageEmbed()
+        embed.set_author(name='Yahoo! Weather')
+        embed.title = result.title[17:]
+        embed.url = result.print_obj['link'].split('*')[-1]
+        embed.description = result.condition.text
+        embed.add_field(
+            name='Temperature',
+            value=f'{result.condition.temp}° {result.units.temperature}',
+            inline=True)
+        embed.add_field(
+            name='Atmosphere',
+            value=self.format_atmosphere(result.atmosphere, result.units),
+            inline=True)
+        embed.add_field(
+            name='Wind',
+            value=self.format_wind(result.wind, result.units),
+            inline=True)
+        embed.add_field(
+            name='Astronomy',
+            value=self.format_astronomy(result),
+            inline=True)
+
+        code = int(result.condition.code)
+
+        if code != 3200:
+            embed.set_thumbnail(url=f'{self.ICON_BASE}{self.ICONS[code]}.png')
+
+        event.msg.reply(embed=embed)
+
+    @staticmethod
+    def format_atmosphere(atm: dict, units: Unit) -> str:
+        state: str = WeatherPlugin.PRESSURE_STATES[int(atm['rising'])]
+
+        return f'Humidity: {atm["humidity"]}%\n' \
+               f'Pressure: {atm["pressure"]} {units.pressure} ({state})\n' \
+               f'Visibility: {atm["visibility"]} {units.distance}'
+
+    @staticmethod
+    def format_wind(wind: Wind, units: Unit) -> str:
+        degrees: str = wind.direction
+        cardinal: str = WeatherPlugin.get_cardinal_dir(degrees)
+
+        return f'{degrees}° ({cardinal}) at {wind.speed} ' \
+               f'{units.speed}\nWind chill: {wind.chill}'
+
+    @staticmethod
+    def format_astronomy(result: WeatherObject) -> str:
+        tz: str = result.last_build_date[-3:]
+        ast: dict = result.astronomy
+
+        return f'Sunrise: {ast["sunrise"]} {tz}\nSunset: {ast["sunset"]} {tz}'
+
+    @staticmethod
+    def get_cardinal_dir(degrees: str) -> str:
+        return WeatherPlugin.CARDINAL_DIRS[int((int(degrees) / 22.5) + 0.5)]

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -152,7 +152,7 @@ class WeatherPlugin(Plugin):
         Formats a string to displays wind information.
         """
         degrees: str = wind.direction
-        cardinal: str = WeatherPlugin.get_cardinal_dir(int(degrees))
+        cardinal: str = WeatherPlugin.get_cardinal_dir(degrees)
 
         return f'{degrees}° ({cardinal}) at {wind.speed} ' \
                f'{units.speed}\nWind chill: {wind.chill}'
@@ -168,11 +168,13 @@ class WeatherPlugin(Plugin):
         return f'Sunrise: {ast["sunrise"]} {tz}\nSunset: {ast["sunset"]} {tz}'
 
     @staticmethod
-    def get_cardinal_dir(degrees: int) -> str:
+    def get_cardinal_dir(degrees: Union[int, str]) -> str:
         """
         Converts degrees to an abbreviated cardinal direction.
         """
-        return WeatherPlugin.CARDINAL_DIRS[int((degrees % 360 / 22.5) + 0.5)]
+        index: int = int((int(degrees) % 360 / 22.5) + 0.5)
+
+        return WeatherPlugin.CARDINAL_DIRS[index]
 
     @staticmethod
     def get_emoji(code: Union[int, str]) -> str:

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -58,7 +58,7 @@ class WeatherPlugin(Plugin):
         # Sometimes the response is OK but only contains units. Assumes failure
         # if some arbitrary top-level element besides units doesn't exist.
         if not result or 'link' not in result.print_obj:
-            event.msg.reply(f'Could not find weather for `{location}`.')
+            event.msg.reply('Could not find weather for `{}`.'.format(location))
             return
 
         embed: MessageEmbed = self.get_base_embed(result)
@@ -98,20 +98,22 @@ class WeatherPlugin(Plugin):
         # Sometimes the response is OK but only contains units. Assumes failure
         # if some arbitrary top-level element besides units doesn't exist.
         if not result or 'link' not in result.print_obj:
-            event.msg.reply(f'Could not retrieve a forecast for `{location}`.')
+            event.msg.reply(
+                'Could not retrieve a forecast for `{}`.'.format(location))
             return
 
         embed: MessageEmbed = self.get_base_embed(result)
-        embed.title = f'10-day Weather Forecast for {result.title[17:]}'
+        embed.title = '10-day Weather Forecast for {}'.format(result.title[17:])
 
         for forecast in result.forecast:
             emoji: str = WeatherPlugin.get_emoji(forecast.code)
 
             embed.add_field(
-                name=f'{forecast.day} ({forecast.date[:6]})',
-                value=f'{emoji}{forecast.text}\n'
-                      f'High: `{forecast.high}° {result.units.temperature}`\n'
-                      f'Low: `{forecast.low}° {result.units.temperature}`',
+                name='{} ({})'.format(forecast.day, forecast.date[:6]),
+                value='{}{}\nHigh: `{}° {}`\nLow: `{}° {}`'.format(
+                    emoji, forecast.text, forecast.high,
+                    result.units.temperature, forecast.low,
+                    result.units.temperature),
                 inline=True)
 
         event.msg.reply(embed=embed)
@@ -138,10 +140,9 @@ class WeatherPlugin(Plugin):
         forecast: Forecast = result.forecast[0]
         emoji: str = WeatherPlugin.get_emoji(result.condition.code)
 
-        return f'{emoji}{result.condition.temp}° {result.units.temperature} ' \
-               f'- {result.condition.text}\n' \
-               f'High: `{forecast.high}° {result.units.temperature}`\n' \
-               f'Low: `{forecast.low}° {result.units.temperature}`'
+        return '{0}{1}° {5} - {2}\nHigh: `{3}° {5}`\nLow: `{4}° {5}`'.format(
+            emoji, result.condition.temp, result.condition.text, forecast.high,
+            forecast.low, result.units.temperature)
 
     @staticmethod
     def format_atmosphere(atm: dict, units: Unit) -> str:
@@ -150,9 +151,9 @@ class WeatherPlugin(Plugin):
         """
         state: str = WeatherPlugin.PRESSURE_STATES[int(atm['rising'])]
 
-        return f'Humidity: `{atm["humidity"]}%`\n' \
-               f'Pressure: `{atm["pressure"]} {units.pressure}` ({state})\n' \
-               f'Visibility: `{atm["visibility"]} {units.distance}`'
+        return 'Humidity: `{}%`\nPressure: `{} {}` ({})\nVisibility: `{} {}`'\
+            .format(atm["humidity"], atm["pressure"], units.pressure, state,
+                    atm["visibility"], units.distance)
 
     @staticmethod
     def format_wind(wind: Wind, units: Unit) -> str:
@@ -162,8 +163,8 @@ class WeatherPlugin(Plugin):
         degrees: str = wind.direction
         cardinal: str = WeatherPlugin.get_cardinal_dir(degrees)
 
-        return f'`{degrees}°` ({cardinal}) at `{wind.speed} {units.speed}`\n' \
-               f'Wind chill: `{wind.chill}`'
+        return '`{}°` ({}) at `{} {}`\nWind chill: `{}`'.format(
+            degrees, cardinal, wind.speed, units.speed, wind.chill)
 
     @staticmethod
     def format_astronomy(result: WeatherObject) -> str:
@@ -173,8 +174,8 @@ class WeatherPlugin(Plugin):
         tz: str = result.last_build_date[-3:]
         ast: dict = result.astronomy
 
-        return f'Sunrise: `{ast["sunrise"]} {tz}`\n' \
-               f'Sunset: `{ast["sunset"]} {tz}`'
+        return 'Sunrise: `{0} {2}`\nSunset: `{1} {2}`'.format(
+            ast["sunrise"], ast["sunset"], tz)
 
     @staticmethod
     def get_cardinal_dir(degrees: Union[int, str]) -> str:
@@ -192,7 +193,7 @@ class WeatherPlugin(Plugin):
         """
         code: int = int(code)
 
-        return f'{WeatherPlugin.ICONS[code][1]} ' if code != 3200 else ''
+        return WeatherPlugin.ICONS[code][1] + ' ' if code != 3200 else ''
 
     @staticmethod
     def get_thumbnail(code: Union[int, str]) -> Optional[str]:
@@ -204,4 +205,4 @@ class WeatherPlugin(Plugin):
         if code != 3200:
             icon: str = WeatherPlugin.ICONS[code][0]
 
-            return f'http://openweathermap.org/img/w/{icon}.png'
+            return 'http://openweathermap.org/img/w/{}.png'.format(icon)

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -56,7 +56,7 @@ class WeatherPlugin(Plugin):
             name='Yahoo! Weather',
             url='https://www.yahoo.com/news/weather',
             icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
-        embed.title = result.title[17:]  # Removes 'Yahoo! Weather - '.
+        embed.title = result.print_obj['item']['title']
         embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
         embed.description = result.condition.text
         embed.add_field(

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -56,7 +56,9 @@ class WeatherPlugin(Plugin):
         """
         result: WeatherObject = self.weather.lookup_by_location(location)
 
-        if not result:
+        # Sometimes the response is OK but only contains units. Assumes failure
+        # if some arbitrary top-level element besides units doesn't exist.
+        if not result or 'link' not in result.print_obj:
             event.msg.reply(f'Could not find weather for `{location}`.')
             return
 
@@ -103,7 +105,9 @@ class WeatherPlugin(Plugin):
         """
         result: WeatherObject = self.weather.lookup_by_location(location)
 
-        if not result:
+        # Sometimes the response is OK but only contains units. Assumes failure
+        # if some arbitrary top-level element besides units doesn't exist.
+        if not result or 'link' not in result.print_obj:
             event.msg.reply(f'Could not retrieve a forecast for `{location}`.')
             return
 

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -111,8 +111,8 @@ class WeatherPlugin(Plugin):
             embed.add_field(
                 name=f'{forecast.day} ({forecast.date[:6]})',
                 value=f'{emoji}{forecast.text}\n'
-                      f'High: {forecast.high}° {result.units.temperature}\n'
-                      f'Low: {forecast.low}° {result.units.temperature}',
+                      f'High: `{forecast.high}° {result.units.temperature}`\n'
+                      f'Low: `{forecast.low}° {result.units.temperature}`',
                 inline=True)
 
         event.msg.reply(embed=embed)
@@ -133,10 +133,10 @@ class WeatherPlugin(Plugin):
         forecast: Forecast = result.forecast[0]
         emoji: str = WeatherPlugin.get_emoji(result.condition.code)
 
-        return f'{emoji}{result.condition.text}\n' \
-               f'{result.condition.temp}° {result.units.temperature}\n' \
-               f'High: {forecast.high}° {result.units.temperature}\n' \
-               f'Low: {forecast.low}° {result.units.temperature}'
+        return f'{emoji}{result.condition.temp}° {result.units.temperature} ' \
+               f'- {result.condition.text}\n' \
+               f'High: `{forecast.high}° {result.units.temperature}`\n' \
+               f'Low: `{forecast.low}° {result.units.temperature}`'
 
     @staticmethod
     def format_atmosphere(atm: dict, units: Unit) -> str:
@@ -145,9 +145,9 @@ class WeatherPlugin(Plugin):
         """
         state: str = WeatherPlugin.PRESSURE_STATES[int(atm['rising'])]
 
-        return f'Humidity: {atm["humidity"]}%\n' \
-               f'Pressure: {atm["pressure"]} {units.pressure} ({state})\n' \
-               f'Visibility: {atm["visibility"]} {units.distance}'
+        return f'Humidity: `{atm["humidity"]}%`\n' \
+               f'Pressure: `{atm["pressure"]} {units.pressure}` ({state})\n' \
+               f'Visibility: `{atm["visibility"]} {units.distance}`'
 
     @staticmethod
     def format_wind(wind: Wind, units: Unit) -> str:
@@ -157,8 +157,8 @@ class WeatherPlugin(Plugin):
         degrees: str = wind.direction
         cardinal: str = WeatherPlugin.get_cardinal_dir(degrees)
 
-        return f'{degrees}° ({cardinal}) at {wind.speed} ' \
-               f'{units.speed}\nWind chill: {wind.chill}'
+        return f'`{degrees}°` ({cardinal}) at `{wind.speed} {units.speed}`\n' \
+               f'Wind chill: `{wind.chill}`'
 
     @staticmethod
     def format_astronomy(result: WeatherObject) -> str:
@@ -168,7 +168,8 @@ class WeatherPlugin(Plugin):
         tz: str = result.last_build_date[-3:]
         ast: dict = result.astronomy
 
-        return f'Sunrise: {ast["sunrise"]} {tz}\nSunset: {ast["sunset"]} {tz}'
+        return f'Sunrise: `{ast["sunrise"]} {tz}`\n' \
+               f'Sunset: `{ast["sunset"]} {tz}`'
 
     @staticmethod
     def get_cardinal_dir(degrees: Union[int, str]) -> str:

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -85,6 +85,43 @@ class WeatherPlugin(Plugin):
 
         event.msg.reply(embed=embed)
 
+    @Plugin.command('forecast', '<location:str...>')
+    def weather_command(self, event: CommandEvent, location: str):
+        """
+        Displays a 10-day weather forecast for a given location.
+
+        Parameters
+        ----------
+        event : CommandEvent
+            The event which was created when this command triggered.
+        location : str
+            The location for which to retrieve a forecast.
+
+        """
+        result: WeatherObject = self.weather.lookup_by_location(location)
+
+        if not result:
+            event.msg.reply(f'Could not retrieve a forecast for `{location}`.')
+            return
+
+        embed: MessageEmbed = MessageEmbed()
+        embed.set_author(
+            name='Yahoo! Weather',
+            url='https://www.yahoo.com/news/weather',
+            icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
+        embed.title = f'10-day Weather Forecast for {result.title[17:]}'
+        embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
+
+        for forecast in result.forecast:
+            embed.add_field(
+                name=f'{forecast.day} ({forecast.date[:6]})',
+                value=f'{forecast.text}\n'
+                      f'High: {forecast.high}° {result.units.temperature}\n'
+                      f'Low: {forecast.low}° {result.units.temperature}',
+                inline=True)
+
+        event.msg.reply(embed=embed)
+
     @staticmethod
     def format_temp(result: WeatherObject):
         forecast: Forecast = result.forecast[0]

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -110,7 +110,7 @@ class WeatherPlugin(Plugin):
         Formats a string to displays wind information.
         """
         degrees: str = wind.direction
-        cardinal: str = WeatherPlugin.get_cardinal_dir(degrees)
+        cardinal: str = WeatherPlugin.get_cardinal_dir(int(degrees))
 
         return f'{degrees}° ({cardinal}) at {wind.speed} ' \
                f'{units.speed}\nWind chill: {wind.chill}'
@@ -126,8 +126,8 @@ class WeatherPlugin(Plugin):
         return f'Sunrise: {ast["sunrise"]} {tz}\nSunset: {ast["sunset"]} {tz}'
 
     @staticmethod
-    def get_cardinal_dir(degrees: str) -> str:
+    def get_cardinal_dir(degrees: int) -> str:
         """
         Converts degrees to an abbreviated cardinal direction.
         """
-        return WeatherPlugin.CARDINAL_DIRS[int((int(degrees) / 22.5) + 0.5)]
+        return WeatherPlugin.CARDINAL_DIRS[int((degrees % 360 / 22.5) + 0.5)]

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -1,7 +1,6 @@
 """
 Functions related to weather.
 """
-
 from typing import Optional, Union
 
 from disco.bot import Plugin
@@ -119,6 +118,9 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def get_base_embed(result: WeatherObject) -> MessageEmbed:
+        """
+        Creates an embed and sets some common properties.
+        """
         embed: MessageEmbed = MessageEmbed()
         embed.set_author(
             name='Yahoo! Weather',
@@ -129,7 +131,10 @@ class WeatherPlugin(Plugin):
         return embed
 
     @staticmethod
-    def format_condition(result: WeatherObject):
+    def format_condition(result: WeatherObject) -> str:
+        """
+        Formats a string displaying the current condition information.
+        """
         forecast: Forecast = result.forecast[0]
         emoji: str = WeatherPlugin.get_emoji(result.condition.code)
 
@@ -182,12 +187,18 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def get_emoji(code: Union[int, str]) -> str:
+        """
+        Returns an emoji based on a condition code.
+        """
         code: int = int(code)
 
         return f'{WeatherPlugin.ICONS[code][1]} ' if code != 3200 else ''
 
     @staticmethod
     def get_thumbnail(code: Union[int, str]) -> Optional[str]:
+        """
+        Returns an OpenWeatherMap icon URL based on a condition code.
+        """
         code: int = int(code)
 
         if code != 3200:

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -13,7 +13,7 @@ class WeatherPlugin(Plugin):
         'N', 'NNE', 'NE', 'ENE', 'E', 'ESE', 'SE', 'SSE', 'S', 'SSW', 'SW',
         'WSW', 'W', 'WNW', 'NW', 'NNW')
     PRESSURE_STATES = ('steady', 'rising', 'falling')
-    UNIT_CHOICES = list(vars(Unit).values())
+    UNIT_CHOICES = ('c', 'f')
 
     # Maps Yahoo's condition codes to OpenWeatherMap's weather icons and emojis.
     ICONS = (

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -65,11 +65,7 @@ class WeatherPlugin(Plugin):
         embed: MessageEmbed = self.get_base_embed(result)
         embed.title = result.print_obj['item']['title']
         embed.set_thumbnail(url=self.get_thumbnail(result.condition.code))
-        embed.description = result.condition.text
-        embed.add_field(
-            name='Temperature',
-            value=self.format_temp(result),
-            inline=True)
+        embed.description = self.format_condition(result)
         embed.add_field(
             name='Atmosphere',
             value=self.format_atmosphere(result.atmosphere, result.units),
@@ -133,10 +129,12 @@ class WeatherPlugin(Plugin):
         return embed
 
     @staticmethod
-    def format_temp(result: WeatherObject):
+    def format_condition(result: WeatherObject):
         forecast: Forecast = result.forecast[0]
+        emoji: str = WeatherPlugin.get_emoji(result.condition.code)
 
-        return f'{result.condition.temp}° {result.units.temperature}\n' \
+        return f'{emoji}{result.condition.text}\n' \
+               f'{result.condition.temp}° {result.units.temperature}\n' \
                f'High: {forecast.high}° {result.units.temperature}\n' \
                f'Low: {forecast.low}° {result.units.temperature}'
 

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -1,6 +1,4 @@
-"""
-Functions related to weather.
-"""
+"""Functions related to weather."""
 from typing import Optional, Union
 
 from disco.bot import Plugin
@@ -40,18 +38,17 @@ class WeatherPlugin(Plugin):
 
     @Plugin.command('weather', '<location:str...>')
     def weather_command(self, event: CommandEvent, location: str):
-        """
+        """= weather =
         Displays the weather for a given location.
-
         Provides information on temperature, atmosphere, wind, & astronomy.
-
-        Parameters
-        ----------
-        event : CommandEvent
-            The event which was created when this command triggered.
-        location : str
-            The location for which to look up the weather.
-
+        usage    :: $weather <location>
+        aliases  :: None
+        category :: Weather
+        == Arguments
+        location :: The location for which to look up the weather.
+        == Examples
+        $weather new york `Looks up the weather for New York city.`
+        $weather tokyo `Looks up the weather for Tokyo city.`
         """
         result: WeatherObject = self.weather.lookup_by_location(location)
 
@@ -82,16 +79,16 @@ class WeatherPlugin(Plugin):
 
     @Plugin.command('forecast', '<location:str...>')
     def forecast_command(self, event: CommandEvent, location: str):
-        """
+        """= forecast =
         Displays a 10-day weather forecast for a given location.
-
-        Parameters
-        ----------
-        event : CommandEvent
-            The event which was created when this command triggered.
-        location : str
-            The location for which to retrieve a forecast.
-
+        usage    :: $forecast <location>
+        aliases  :: None
+        category :: Weather
+        == Arguments
+        location :: The location for which to retrieve a forecast.
+        == Examples
+        $forecast new york `Looks up the forecast for New York city.`
+        $forecast tokyo `Looks up the forecast for Tokyo city.`
         """
         result: WeatherObject = self.weather.lookup_by_location(location)
 
@@ -120,9 +117,7 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def get_base_embed(result: WeatherObject) -> MessageEmbed:
-        """
-        Creates an embed and sets some common properties.
-        """
+        """Creates an embed and sets some common properties."""
         embed: MessageEmbed = MessageEmbed()
         embed.set_author(
             name='Yahoo! Weather',
@@ -134,9 +129,7 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def format_condition(result: WeatherObject) -> str:
-        """
-        Formats a string displaying the current condition information.
-        """
+        """Formats a string displaying the current condition information."""
         forecast: Forecast = result.forecast[0]
         emoji: str = WeatherPlugin.get_emoji(result.condition.code)
 
@@ -146,9 +139,7 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def format_atmosphere(atm: dict, units: Unit) -> str:
-        """
-        Formats a string to displays atmosphere information.
-        """
+        """Formats a string to displays atmosphere information."""
         state: str = WeatherPlugin.PRESSURE_STATES[int(atm['rising'])]
 
         return 'Humidity: `{}%`\nPressure: `{} {}` ({})\nVisibility: `{} {}`'\
@@ -157,9 +148,7 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def format_wind(wind: Wind, units: Unit) -> str:
-        """
-        Formats a string to displays wind information.
-        """
+        """Formats a string to displays wind information."""
         degrees: str = wind.direction
         cardinal: str = WeatherPlugin.get_cardinal_dir(degrees)
 
@@ -168,9 +157,7 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def format_astronomy(result: WeatherObject) -> str:
-        """
-        Formats a string to displays astronomy information.
-        """
+        """Formats a string to displays astronomy information."""
         tz: str = result.last_build_date[-3:]
         ast: dict = result.astronomy
 
@@ -179,27 +166,21 @@ class WeatherPlugin(Plugin):
 
     @staticmethod
     def get_cardinal_dir(degrees: Union[int, str]) -> str:
-        """
-        Converts degrees to an abbreviated cardinal direction.
-        """
+        """Converts degrees to an abbreviated cardinal direction."""
         index: int = int((int(degrees) % 360 / 22.5) + 0.5)
 
         return WeatherPlugin.CARDINAL_DIRS[index]
 
     @staticmethod
     def get_emoji(code: Union[int, str]) -> str:
-        """
-        Returns an emoji based on a condition code.
-        """
+        """Returns an emoji based on a condition code."""
         code: int = int(code)
 
         return WeatherPlugin.ICONS[code][1] + ' ' if code != 3200 else ''
 
     @staticmethod
     def get_thumbnail(code: Union[int, str]) -> Optional[str]:
-        """
-        Returns an OpenWeatherMap icon URL based on a condition code.
-        """
+        """Returns an OpenWeatherMap icon URL based on a condition code."""
         code: int = int(code)
 
         if code != 3200:

--- a/A2/plugins/weather.py
+++ b/A2/plugins/weather.py
@@ -24,9 +24,6 @@ class WeatherPlugin(Plugin):
         '02d', '01n', '01d', '01n', '01d', '09d', '01d', '11d', '11d', '11d',
         '09d', '13d', '13d', '13d', '04d', '11d', '13d', '11d')
 
-    # Base URL for OpenWeatherMap's weather icons. All icons have .png suffix.
-    ICON_BASE = 'http://openweathermap.org/img/w/'
-
     def __init__(self, bot, config):
         super().__init__(bot, config)
 
@@ -54,9 +51,12 @@ class WeatherPlugin(Plugin):
             return
 
         embed: MessageEmbed = MessageEmbed()
-        embed.set_author(name='Yahoo! Weather')
-        embed.title = result.title[17:]
-        embed.url = result.print_obj['link'].split('*')[-1]
+        embed.set_author(
+            name='Yahoo! Weather',
+            url='https://www.yahoo.com/news/weather',
+            icon_url='https://s.yimg.com/dh/ap/default/130909/y_200_a.png')
+        embed.title = result.title[17:]  # Removes 'Yahoo! Weather - '.
+        embed.url = result.print_obj['link'].split('*')[-1]  # Removes RSS URL.
         embed.description = result.condition.text
         embed.add_field(
             name='Temperature',
@@ -79,7 +79,8 @@ class WeatherPlugin(Plugin):
 
         # 3200 = Unknown condition.
         if code != 3200:
-            embed.set_thumbnail(url=f'{self.ICON_BASE}{self.ICONS[code]}.png')
+            embed.set_thumbnail(
+                url=f'http://openweathermap.org/img/w/{self.ICONS[code]}.png')
 
         event.msg.reply(embed=embed)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -e git+git://github.com/b1naryth1ef/disco.git#egg=disco-py
+weather-api>=1.0.4


### PR DESCRIPTION
This plugin uses [Yahoo's weather API](https://developer.yahoo.com/weather/documentation.html) via the [weather-api](https://github.com/AnthonyBloomer/weather-api) Python wrapper. The plugin has two commands : `weather` and `forecast`. The former displays the current weather for a given location while the latter provides a 10-day forecast.

* Commands display weather information in an embed.
* Location is provided as a string argument. Meant to be specific e.g. a city or county.
* If weather for a location cannot be found, an error message is instead sent.
* All units default to metric. The API supports Fahrenheit/imperial units, but the plugin currently has no means of accommodating that functionality.

### Considerations
* ~~The code makes use of [f-strings](https://www.python.org/dev/peps/pep-0498/), a feature available only in Python 3.6+.~~
